### PR TITLE
feat: コンポーネントの廃棄処理の仕組みを追加

### DIFF
--- a/src/main/java/nablarch/fw/launcher/Main.java
+++ b/src/main/java/nablarch/fw/launcher/Main.java
@@ -14,6 +14,7 @@ import nablarch.core.repository.SystemRepository;
 import nablarch.core.repository.di.DiContainer;
 import nablarch.core.repository.di.config.DuplicateDefinitionPolicy;
 import nablarch.core.repository.di.config.xml.XmlComponentDefinitionLoader;
+import nablarch.core.repository.disposal.ApplicationDisposer;
 import nablarch.core.util.StringUtil;
 import nablarch.core.util.annotation.Published;
 import nablarch.fw.DataReader;
@@ -146,6 +147,11 @@ public class Main extends HandlerQueueManager<Main>
         } catch (Error e) {
             FailureLogUtil.logFatal(e, null, null, new Object[0]);
             return UNKNOWN_ERROR;
+        } finally {
+            ApplicationDisposer disposer = SystemRepository.get("disposer");
+            if (disposer != null) {
+                disposer.dispose();
+            }
         }
 
         if (result instanceof Integer) {

--- a/src/test/java/nablarch/fw/launcher/MockDisposable.java
+++ b/src/test/java/nablarch/fw/launcher/MockDisposable.java
@@ -1,0 +1,16 @@
+package nablarch.fw.launcher;
+
+import nablarch.core.repository.disposal.Disposable;
+
+public class MockDisposable implements Disposable {
+    private boolean disposed;
+
+    @Override
+    public void dispose() throws Exception {
+        disposed = true;
+    }
+
+    public boolean isDisposed() {
+        return disposed;
+    }
+}

--- a/src/test/resources/nablarch/fw/launcher/disposerTest.xml
+++ b/src/test/resources/nablarch/fw/launcher/disposerTest.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component-configuration
+    xmlns="http://tis.co.jp/nablarch/component-configuration"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://tis.co.jp/nablarch/component-configuration">
+
+  <import file="db-default.xml" />
+
+  <component name="businessDateProvider" class="nablarch.fw.mock.MockBusinessDateProvider">
+    <property name="date" value="20170101"/>
+  </component>
+
+  <list name="handlerQueue">
+    <component class="nablarch.fw.handler.StatusCodeConvertHandler" />
+    <component class="nablarch.fw.handler.GlobalErrorHandler" />
+    <component class="nablarch.fw.handler.RequestPathJavaPackageMapping">
+      <property name="immediate" value="false" />
+    </component>
+    <component class="nablarch.fw.handler.MultiThreadExecutionHandler" />
+    <component class="nablarch.common.handler.DbConnectionManagementHandler">
+      <property name="connectionFactory" ref="connectionFactory" />
+    </component>
+    <component class="nablarch.fw.handler.LoopHandler">
+      <property name="commitInterval" value="1" />
+      <property name="transactionFactory" ref="jdbcTransactionFactory" />
+    </component>
+    <component class="nablarch.fw.handler.DataReadHandler" />
+  </list>
+  
+  <component name="disposable1" class="nablarch.fw.launcher.MockDisposable" />
+  <component name="disposable2" class="nablarch.fw.launcher.MockDisposable" />
+  <component name="disposable3" class="nablarch.fw.launcher.MockDisposable" />
+
+  <component name="disposer" class="nablarch.core.repository.disposal.BasicApplicationDisposer">
+    <property name="disposableList">
+      <list>
+        <component-ref name="disposable1" />
+        <component-ref name="disposable2" />
+        <component-ref name="disposable3" />
+      </list>
+    </property>
+  </component>
+
+</component-configuration>

--- a/src/test/resources/nablarch/fw/launcher/disposerTestErrorCase.xml
+++ b/src/test/resources/nablarch/fw/launcher/disposerTestErrorCase.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component-configuration
+    xmlns="http://tis.co.jp/nablarch/component-configuration"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://tis.co.jp/nablarch/component-configuration">
+
+  <list name="handlerQueue">
+    <component class="nablarch.fw.launcher.MainTest$ResultErrorHandler" />
+  </list>
+  
+  <component name="disposable1" class="nablarch.fw.launcher.MockDisposable" />
+  <component name="disposable2" class="nablarch.fw.launcher.MockDisposable" />
+  <component name="disposable3" class="nablarch.fw.launcher.MockDisposable" />
+
+  <component name="disposer" class="nablarch.core.repository.disposal.BasicApplicationDisposer">
+    <property name="disposableList">
+      <list>
+        <component-ref name="disposable1" />
+        <component-ref name="disposable2" />
+        <component-ref name="disposable3" />
+      </list>
+    </property>
+  </component>
+
+</component-configuration>

--- a/src/test/resources/nablarch/fw/launcher/disposerTestNotExists.xml
+++ b/src/test/resources/nablarch/fw/launcher/disposerTestNotExists.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component-configuration
+    xmlns="http://tis.co.jp/nablarch/component-configuration"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://tis.co.jp/nablarch/component-configuration">
+
+  <list name="handlerQueue">
+    <component class="nablarch.fw.launcher.MainTest$ResultErrorHandler" />
+  </list>
+
+  <component name="disposable1" class="nablarch.fw.launcher.MockDisposable" />
+  <component name="disposable2" class="nablarch.fw.launcher.MockDisposable" />
+  <component name="disposable3" class="nablarch.fw.launcher.MockDisposable" />
+
+</component-configuration>


### PR DESCRIPTION
バッチが終了するときに、 `ApplicationDisposer` のコンポーネントを `SystemRepository` から取り出して、存在すれば廃棄処理を実行するようにする修正を入れました。