### PR TITLE
行カバレッジ未達部分を補完

### DIFF
--- a/src/test/java/nablarch/fw/launcher/MainTest.java
+++ b/src/test/java/nablarch/fw/launcher/MainTest.java
@@ -223,6 +223,22 @@ public class MainTest {
         assertThat("正常終了なので戻り値は0となる。", exitCode, is(0));
     }
 
+    /**
+     * {@link Result} 以外の値が返された場合は正常終了扱いにする。
+     */
+    @Test
+    public void testReturnNonResult() {
+        CommandLine commandLine = new CommandLine(
+                "-diConfig", "nablarch/fw/launcher/testReturnNonResult.xml",
+                "-requestPath",
+                "nablarch.fw.launcher.testaction.ReturnNonResultAction/RS100",
+                "-userId", "hoge"
+        );
+
+        int exitCode = Main.execute(commandLine);
+        assertThat("正常終了扱いなので0を返す。", exitCode, is(0));
+    }
+
     public static class ErrorHandler implements Handler<Object, Object> {
 
         @Override

--- a/src/test/java/nablarch/fw/launcher/MainTest.java
+++ b/src/test/java/nablarch/fw/launcher/MainTest.java
@@ -206,6 +206,23 @@ public class MainTest {
         assertThat(disposable3.isDisposed(), is(false));
     }
 
+    /**
+     * {@link nablarch.fw.handler.StatusCodeConvertHandler} がハンドラキューに
+     * 設定されておらず {@link Result} がそのまま返されたときも戻り値が正常に処理されることのテスト（正常終了時）。
+     */
+    @Test
+    public void testWithoutStatusCodeConvertHandlerInSuccessCase() {
+        CommandLine commandLine = new CommandLine(
+                "-diConfig", "nablarch/fw/launcher/testWithoutStatusCodeConvertHandler.xml",
+                "-requestPath",
+                "nablarch.fw.launcher.testaction.NormalEndAction/RS100",
+                "-userId", "hoge"
+        );
+
+        int exitCode = Main.execute(commandLine);
+        assertThat("正常終了なので戻り値は0となる。", exitCode, is(0));
+    }
+
     public static class ErrorHandler implements Handler<Object, Object> {
 
         @Override

--- a/src/test/java/nablarch/fw/launcher/MainTest.java
+++ b/src/test/java/nablarch/fw/launcher/MainTest.java
@@ -239,6 +239,22 @@ public class MainTest {
         assertThat("正常終了扱いなので0を返す。", exitCode, is(0));
     }
 
+    /**
+     * diConfig パラメータに空文字が設定された場合は異常終了とする。
+     */
+    @Test
+    public void testErrorEndIfDiConfigParameterIsNotSet() {
+        CommandLine commandLine = new CommandLine(
+                "-diConfig", "",
+                "-requestPath",
+                "nablarch.fw.launcher.testaction.NormalEndAction/RS100",
+                "-userId", "hoge"
+        );
+
+        int exitCode = Main.execute(commandLine);
+        assertThat("不明なエラー扱いとなる", exitCode, is(127));
+    }
+
     public static class ErrorHandler implements Handler<Object, Object> {
 
         @Override

--- a/src/test/java/nablarch/fw/launcher/testaction/ReturnNonResultAction.java
+++ b/src/test/java/nablarch/fw/launcher/testaction/ReturnNonResultAction.java
@@ -1,0 +1,12 @@
+package nablarch.fw.launcher.testaction;
+
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.Handler;
+import nablarch.fw.launcher.CommandLine;
+
+public class ReturnNonResultAction implements Handler<CommandLine, String> {
+    @Override
+    public String handle(CommandLine commandLine, ExecutionContext context) {
+        return "non result";
+    }
+}

--- a/src/test/resources/nablarch/fw/launcher/testReturnNonResult.xml
+++ b/src/test/resources/nablarch/fw/launcher/testReturnNonResult.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component-configuration
+    xmlns="http://tis.co.jp/nablarch/component-configuration"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://tis.co.jp/nablarch/component-configuration">
+
+  <import file="db-default.xml" />
+
+  <component name="businessDateProvider" class="nablarch.fw.mock.MockBusinessDateProvider">
+    <property name="date" value="20170101"/>
+  </component>
+
+  <list name="handlerQueue">
+    <component class="nablarch.fw.handler.RequestPathJavaPackageMapping">
+      <property name="immediate" value="false" />
+    </component>
+  </list>
+
+</component-configuration>

--- a/src/test/resources/nablarch/fw/launcher/testWithoutStatusCodeConvertHandler.xml
+++ b/src/test/resources/nablarch/fw/launcher/testWithoutStatusCodeConvertHandler.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component-configuration
+    xmlns="http://tis.co.jp/nablarch/component-configuration"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://tis.co.jp/nablarch/component-configuration">
+
+  <import file="db-default.xml" />
+
+  <component name="businessDateProvider" class="nablarch.fw.mock.MockBusinessDateProvider">
+    <property name="date" value="20170101"/>
+  </component>
+
+  <list name="handlerQueue">
+    <component class="nablarch.fw.handler.GlobalErrorHandler" />
+    <component class="nablarch.fw.handler.RequestPathJavaPackageMapping">
+      <property name="immediate" value="false" />
+    </component>
+    <component class="nablarch.fw.handler.MultiThreadExecutionHandler" />
+    <component class="nablarch.common.handler.DbConnectionManagementHandler">
+      <property name="connectionFactory" ref="connectionFactory" />
+    </component>
+    <component class="nablarch.fw.handler.LoopHandler">
+      <property name="commitInterval" value="1" />
+      <property name="transactionFactory" ref="jdbcTransactionFactory" />
+    </component>
+    <component class="nablarch.fw.handler.DataReadHandler" />
+  </list>
+
+</component-configuration>


### PR DESCRIPTION
Micrometerアダプタ対応の一環（廃棄処理の追加）で `Main` クラスに手を入れたが、既存コード部分で行カバレッジ未達の部分が多数あることが分かった。
今後のことも考えて、テストケースを追加した。

- ハンドラキューの最終的な戻り値が `Integer` の場合しかテストケースがなかったので、以下2つを追加
    - `Result` を返すケースを追加
    - `Integer` でも `Result` でもないケースを追加
- `diConfig` パラメータに空文字が渡されている場合もエラー終了にするテストケースがなかったので追加
- `getHandlerQueue()` に対するテストケースがなかったので追加
