### PR TITLE
設定値追加

### DIFF
--- a/src/test/resources/db.config
+++ b/src/test/resources/db.config
@@ -1,2 +1,4 @@
 // 別プロセスでアプリ実行するテストがあるのでmemではなくfileデータベースを使う
 db.url = jdbc:h2:file:~/ssd;LOCK_TIMEOUT=15000;AUTO_SERVER=TRUE
+db.user = sa
+db.password = pass


### PR DESCRIPTION
今まではユニットテストでDBユーザとパスワードが設定されておらず、${db.user}、${db.password}という文字列が設定されていたが、nablarch-core-repositoryの以下の変更で例外が発生するようになりテストに失敗する状態になった。
https://github.com/nablarch/nablarch-core-repository/pull/24

${db.user}、${db.password}のような値が使われるのは本来は設定不備だが、これらの値はH2のデータベース作成時に使われており${}のような値であっても問題はなく動いてしまっていた。
本来はDBユーザ、パスワードに値を設定するべきなのでconfigファイルを修正。